### PR TITLE
Fix payload formatting

### DIFF
--- a/sections/spaces.md
+++ b/sections/spaces.md
@@ -91,7 +91,7 @@ Invite to space
 
 Upon success, `200 OK` will be returned along with a response with the following schema:
 
-```json
+```
 {
   "participants":[{
     "id": integer,


### PR DESCRIPTION
participants response was flagged as json, but was invalid json. Removed json tag so displays correctly.